### PR TITLE
Fix: Redis isn't exist in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,18 @@ env:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    name: test
     strategy:
       matrix:
         elixir: ['1.10.x', '1.11.x']
         erlang: ['22.x', '23.x']
         os: [ubuntu-latest]
-    name: test
+    runs-on: ${{ matrix.os }}
+    services:
+      redis:
+        image: redis
+        ports:
+          - 6379:6379
     steps:
       - uses: actions/setup-elixir@v1
         with:


### PR DESCRIPTION
[Creating Redis service containers - GitHub Docs](https://docs.github.com/en/free-pro-team@latest/actions/guides/creating-redis-service-containers)

I missed this by `mix cotton.init.github` at https://github.com/ne-sachirou/redis_z/commit/62cc4168c4023d8a77251e550665242a67bfd4ff